### PR TITLE
docs: replace tinywasm/binary with tinywasm/json in API refactor issue

### DIFF
--- a/docs/issues/REFACTOR_SIMPLIFY_API.md
+++ b/docs/issues/REFACTOR_SIMPLIFY_API.md
@@ -182,4 +182,4 @@ This is a complete API rewrite. All existing code using this library must be upd
 - Remove `client := fg.NewClient(...)` pattern
 - Replace `client.SendJSON()` with `fetch.Post().Body(encodedData).Send()`
 - Replace `client.SendBinary()` with `fetch.Post().Body(encodedData).Send()`
-- User must encode/decode data manually using `tinywasm/json` or `tinywasm/binary`
+- User must encode/decode data manually using `github.com/tinywasm/json`


### PR DESCRIPTION
Replaced tinywasm/binary with tinywasm/json in REFACTOR_SIMPLIFY_API.md to ensure no defaults are expected and only json is used as an example payload format. Tested and verified changes.

---
*PR created automatically by Jules for task [6279928361051717134](https://jules.google.com/task/6279928361051717134) started by @cdvelop*